### PR TITLE
Replaced references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ To facilitate tool integration Arm provides critical foundation tools in a tools
 
 URL / Tool     | Description
 :--------------|:-------------------
-[artifacts.tools.arm.com/avh/](https://artifacts.tools.arm.com/avh/)                      | [Arm Virtual Hardware FVP Models](https://arm-software.github.io/AVH/main/simulation/html/Using.html)
-[artifacts.tools.arm.com/cmsis-toolbox/](https://artifacts.tools.arm.com/cmsis-toolbox/)  | [CLI Build System for CMSIS-Pack based projects](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/README.md#cmsis-toolbox)
+[artifacts.tools.arm.com/avh/](https://artifacts.tools.arm.com/avh/)                      | [Arm Virtual Hardware FVP Models](https://arm-software.github.io/AVH/main/simulation/html/index.html)
+[artifacts.tools.arm.com/cmsis-toolbox/](https://artifacts.tools.arm.com/cmsis-toolbox/)  | [CLI Build System for CMSIS-Pack based projects](https://open-cmsis-pack.github.io/cmsis-toolbox/)
 [artifacts.tools.arm.com/arm-compiler/](https://artifacts.tools.arm.com/arm-compiler/)      | [Arm Compiler for Embedded](https://developer.arm.com/Tools%20and%20Software/Arm%20Compiler%20for%20Embedded) (commercial)
 [artifacts.tools.arm.com/arm-none-eabi-gcc/](https://artifacts.tools.arm.com/arm-none-eabi-gcc/) | [Arm GNU Toolchain](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) (community supported); not recommended for Cortex-M with Helium
 [github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/](https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/latest/) | [Arm LLVM Embedded Toolchain](https://learn.arm.com/install-guides/llvm-embedded/) (community supported)


### PR DESCRIPTION
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox/... to https://open-cmsis-pack.github.io/cmsis-toolbox/ a.o
[Issue 248](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/248)